### PR TITLE
Added mechanism to define custom levels at startup

### DIFF
--- a/docs/console.html
+++ b/docs/console.html
@@ -68,6 +68,7 @@ to <code>io.stdout</code>.</p>
 function logging.console {
     [logPattern = <i>string</i>],
     [timestampPattern = <i>string</i>],
+    [levels = <i>array of custom log-levels</i>],
 }
 </pre>
 

--- a/docs/email.html
+++ b/docs/email.html
@@ -76,6 +76,7 @@ function logging.email {
     [headers = <i>table</i>,]
     [logPattern = <i>string</i>,]
     [timestampPattern = <i>string</i>],
+    [levels = <i>array of custom log-levels</i>],
 }
 </pre>
 

--- a/docs/file.html
+++ b/docs/file.html
@@ -70,6 +70,7 @@ function logging.file {
     [datePattern = <i>string</i>,]
     [logPattern = <i>string</i>,]
     [timestampPattern = <i>string</i>],
+    [levels = <i>array of custom log-levels</i>],
 }
 </pre>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -114,8 +114,8 @@ LuaLogging can be downloaded from its
 <h2><a name="history"></a>History</h2>
 
 <dl class="history">
-		<dt><strong>1.x.0</strong> [unreleased]</dt>
-		<dd>Added: Functionality to specify custom log levels.</dd>
+    <dt><strong>1.x.0</strong> [unreleased]</dt>
+    <dd>Added: Functionality to specify custom log levels.</dd>
 
     <dt><strong>1.4.0</strong> [12/Aug/2020]</dt>
     <dd>Fix: No more global on Lua 5.3.</dd>

--- a/docs/index.html
+++ b/docs/index.html
@@ -74,7 +74,7 @@ as Lua 5.1.
 <h2><a name="status"></a>Status</h2>
 
 <p>
-Current version is 1.4.1. It was developed for Lua 5.1+.
+Current version is 1.4.0. It was developed for Lua 5.1+.
 </p>
 
 <h2><a name="download"></a>Download</h2>
@@ -114,9 +114,9 @@ LuaLogging can be downloaded from its
 <h2><a name="history"></a>History</h2>
 
 <dl class="history">
-		<dt><strong>1.4.1</strong> [18/Aug/2020]</dt>
+		<dt><strong>1.x.0</strong> [unreleased]</dt>
 		<dd>Added: Functionality to specify custom log levels.</dd>
-		
+
     <dt><strong>1.4.0</strong> [12/Aug/2020]</dt>
     <dd>Fix: No more global on Lua 5.3.</dd>
     <dd>Fix: Reduced log noise when changing log levels.</dd>

--- a/docs/index.html
+++ b/docs/index.html
@@ -74,7 +74,7 @@ as Lua 5.1.
 <h2><a name="status"></a>Status</h2>
 
 <p>
-Current version is 1.4.0. It was developed for Lua 5.1+.
+Current version is 1.4.1. It was developed for Lua 5.1+.
 </p>
 
 <h2><a name="download"></a>Download</h2>
@@ -114,6 +114,9 @@ LuaLogging can be downloaded from its
 <h2><a name="history"></a>History</h2>
 
 <dl class="history">
+		<dt><strong>1.4.1</strong> [18/Aug/2020]</dt>
+		<dd>Added: Functionality to specify custom log levels.</dd>
+		
     <dt><strong>1.4.0</strong> [12/Aug/2020]</dt>
     <dd>Fix: No more global on Lua 5.3.</dd>
     <dd>Fix: Reduced log noise when changing log levels.</dd>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -110,6 +110,11 @@ defined as <code>logger.WARN</code> then <code>logger.INFO</code> and
 <code>logger.DEBUG</code> level messages are not logged.
 The default set level at startup is <code>logger.DEBUG</code> or the first level enumerated in the custom levels array.</p>
 
+<h3>Constants</h3>
+
+<p>The following set of constants is dynamically generated from the log-levels.
+The ones listed here are based on the default log-levels:</p>
+
 <dl class="reference">
     <dt><strong>logger.DEBUG</strong></dt>
     <dd>The <em>DEBUG</em> level designates fine-grained informational events that
@@ -133,7 +138,7 @@ The default set level at startup is <code>logger.DEBUG</code> or the first level
     <dt><strong>logger.OFF</strong></dt>
     <dd>The <em>OFF</em> level will stop all log messages.</dd>
 </dl>
-<p>Note: when using custom levels it is strongly adviced to NOT remove levels, but
+<p>Note: when using custom levels it is strongly advised to NOT remove levels, but
   only add to the default set. When using libraries that expect the default ones,
   one would otherwise encounter errors if they are not found.
 </p>
@@ -143,6 +148,20 @@ The default set level at startup is <code>logger.DEBUG</code> or the first level
 <dl class="reference">
     <dt><strong>logger:log (level, [message]|[table]|[format, ...]|[function, ...])</strong></dt>
     <dd>Logs a message with the specified level.</dd>
+
+    <dt><strong>logger:setLevel (level)</strong></dt>
+    <dd>This method sets a minimum level for messages to be logged.</dd>
+
+    <dt><strong>logger:getPrint (level)</strong></dt>
+    <dd>This method returns a print-like function that redirects all output to
+    the logger instead of the console. The <code>level</code> parameter specifies
+    the log-level of the output.</dd>
+</dl>
+
+<p>The following set of methods is dynamically generated from the log-levels.
+The ones listed here are based on the default log-levels:</p>
+
+<dl class="reference">
 
     <dt><strong>logger:debug ([message]|[table]|[format, ...]|[function, ...])</strong></dt>
     <dd>Logs a message with DEBUG level.</dd>
@@ -158,14 +177,6 @@ The default set level at startup is <code>logger.DEBUG</code> or the first level
 
     <dt><strong>logger:fatal ([message]|[table]|[format, ...]|[function, ...])</strong></dt>
     <dd>Logs a message with FATAL level.</dd>
-
-    <dt><strong>logger:setLevel (level)</strong></dt>
-    <dd>This method sets a minimum level for messages to be logged.</dd>
-
-    <dt><strong>logger:getPrint (level)</strong></dt>
-    <dd>This method returns a print-like function that redirects all output to
-    the logger instead of the console. The <code>level</code> parameter specifies
-    the log-level of the output.</dd>
 </dl>
 
 <h2><a name="examples"></a>Examples</h2>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -81,10 +81,13 @@ that will be called on each call to log a message.</p>
     <li><strong>level</strong>: the logging level</li>
     <li><strong>message</strong>: the message to be logged</li>
 </ul>
-<p>The logger constructor also receives an optional second argument which should be an
-array of custom level names (strings). Note that no level name should be one of the reserved names
-in a logger object which are <code>append</code> <code>log</code> <code>setlevel</code> <code>getprint</code>
-(case insensitive)</p>
+<p>The logger constructor also receives a optional second argument which should
+be a table with parameters. Currently there is only one:</p>
+<ul>
+  <li><strong>levels</strong>: array of custom level names (strings). Levels will
+  be added as ALLCAPS constants, and as lowercase functions (note that level
+  names must not collide with existing properties or an error will be returned)</li>
+</ul>
 
 <h2><a name="installation"></a>Installation</h2>
 
@@ -100,7 +103,8 @@ or alternatively using the <code>Makefile</code>.</p>
 not only strings. When necessary <code>message</code> is converted to a string.</p>
 
 <p>The parameter <code>level</code> can be one of the variables enumerated below.
-If custom levels are defined then they would be the variables enumerated in the custom levels array.
+If custom levels are defined then they would be the variables enumerated in the
+custom levels array.
 The values are presented in descending criticality, so if the minimum level is
 defined as <code>logger.WARN</code> then <code>logger.INFO</code> and
 <code>logger.DEBUG</code> level messages are not logged.
@@ -129,6 +133,10 @@ The default set level at startup is <code>logger.DEBUG</code> or the first level
     <dt><strong>logger.OFF</strong></dt>
     <dd>The <em>OFF</em> level will stop all log messages.</dd>
 </dl>
+<p>Note: when using custom levels it is strongly adviced to NOT remove levels, but
+  only add to the default set. When using libraries that expect the default ones,
+  one would otherwise encounter errors if they are not found.
+</p>
 
 <h3>Methods</h3>
 
@@ -173,7 +181,11 @@ local appender = function(self, level, message)
   return true
 end
 
-local logger = Logging.new(appender)
+local params = {
+  levels = { "Debug", "Info", "Warn", "Error", "Fatal", "Off" },
+}
+
+local logger = Logging.new(appender, params)
 
 logger:setLevel(logger.WARN)
 logger:log(logger.INFO, "sending email")

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -81,6 +81,10 @@ that will be called on each call to log a message.</p>
     <li><strong>level</strong>: the logging level</li>
     <li><strong>message</strong>: the message to be logged</li>
 </ul>
+<p>The logger constructor also receives an optional second argument which should be an
+array of custom level names (strings). Note that no level name should be one of the reserved names
+in a logger object which are <code>append</code> <code>log</code> <code>setlevel</code> <code>getprint</code>
+(case insensitive)</p>
 
 <h2><a name="installation"></a>Installation</h2>
 
@@ -96,9 +100,11 @@ or alternatively using the <code>Makefile</code>.</p>
 not only strings. When necessary <code>message</code> is converted to a string.</p>
 
 <p>The parameter <code>level</code> can be one of the variables enumerated below.
+If custom levels are defined then they would be the variables enumerated in the custom levels array.
 The values are presented in descending criticality, so if the minimum level is
 defined as <code>logger.WARN</code> then <code>logger.INFO</code> and
-<code>logger.DEBUG</code> level messages are not logged.</p>
+<code>logger.DEBUG</code> level messages are not logged.
+The default set level at startup is <code>logger.DEBUG</code> or the first level enumerated in the custom levels array.</p>
 
 <dl class="reference">
     <dt><strong>logger.DEBUG</strong></dt>

--- a/docs/rolling_file.html
+++ b/docs/rolling_file.html
@@ -72,6 +72,7 @@ function logging.rolling_file {
     [maxBackupIndex = <i>number</i>,]
     [logPattern = <i>string</i>,]
     [timestampPattern = <i>string</i>],
+    [levels = <i>array of custom log-levels</i>],
 }
 </pre>
 

--- a/docs/socket.html
+++ b/docs/socket.html
@@ -74,6 +74,7 @@ function logging.socket {
     port = <i>number</i>,
     [logPattern = <i>string</i>,]
     [timestampPattern = <i>string</i>],
+    [levels = <i>array of custom log-levels</i>],
 }
 </pre>
 

--- a/docs/sql.html
+++ b/docs/sql.html
@@ -73,6 +73,7 @@ function logging.sql{
     [loglevelfield = <i>string</i>,]
     [logmessagefield = <i>string</i>,]
     [keepalive = <i>boolean</i>],
+    [levels = <i>array of custom log-levels</i>],
 }
 </pre>
 

--- a/src/logging.lua
+++ b/src/logging.lua
@@ -16,35 +16,13 @@ local pairs = pairs
 local ipairs = ipairs
 
 local logging = {
-	-- Meta information
-	_COPYRIGHT = "Copyright (C) 2004-2020 Kepler Project",
-	_DESCRIPTION = "A simple API to use logging features in Lua",
-	_VERSION = "LuaLogging 1.4.1",
+  -- Meta information
+  _COPYRIGHT = "Copyright (C) 2004-2020 Kepler Project",
+  _DESCRIPTION = "A simple API to use logging features in Lua",
+  _VERSION = "LuaLogging 1.4.0",
 }
 
-local DEFAULT_LEVELS = {
-	-- The DEBUG Level designates fine-grained instring.formational events that are most
-	-- useful to debug an application
-	"DEBUG",
-
-	-- The INFO level designates instring.formational messages that highlight the
-	-- progress of the application at coarse-grained level
-	"INFO",
-
-	-- The WARN level designates potentially harmful situations
-	"WARN",
-
-	-- The ERROR level designates error events that might still allow the
-	-- application to continue running
-	"ERROR",
-
-	-- The FATAL level designates very severe error events that will presumably
-	-- lead the application to abort
-	"FATAL",
-
-	-- The OFF level designates the logging of nothing at all
-	"OFF",
-}
+local DEFAULT_LEVELS = { "DEBUG", "INFO", "WARN", "ERROR", "FATAL", "OFF" }
 
 -- private log function, with support for formating a complex log message.
 local function LOG_MSG(self, level, fmt, ...)
@@ -110,8 +88,8 @@ function logging.new(append, params)
   end
 
   local LEVELS = {}
-	local MAX_LEVELS = #levels
-	local LEVEL_FUNCS = {}
+  local MAX_LEVELS = #levels
+  local LEVEL_FUNCS = {}
 
   for i, level in ipairs(levels) do
     level = level:upper()
@@ -163,17 +141,17 @@ function logging.new(append, params)
     end
   end
 
-	-- create the proxy functions for each log level.
-	for i=1, MAX_LEVELS do
-		local level = LEVELS[i]
+  -- create the proxy functions for each log level.
+  for i=1, MAX_LEVELS do
+    local level = LEVELS[i]
     if logger[level:lower()] then
       return nil, "'" .. level .."' is not a proper level name since there is already a property '" .. level:lower() .. "'"
     end
-		LEVEL_FUNCS[i] = function(self, ...)
-			-- no level checking needed here, this function will only be called if it's level is active.
-			return LOG_MSG(self, level, ...)
-		end
-	end
+    LEVEL_FUNCS[i] = function(self, ...)
+      -- no level checking needed here, this function will only be called if it's level is active.
+      return LOG_MSG(self, level, ...)
+    end
+  end
 
   -- insert log level constants
   for i=1, MAX_LEVELS do

--- a/src/logging.lua
+++ b/src/logging.lua
@@ -94,16 +94,17 @@ end
 -- Creates a new logger object
 -- @param append Function used by the logger to append a message with a
 -- log-level to the log stream.
--- @param levels optional array of custom logging levels
+-- @param params optional table with parameters. Only 1 supported;
+-- `levels`: optional array of custom logging levels
 -- @return Table representing the new logger object.
 -- @return String if there was any error setting the custom levels if provided
 -------------------------------------------------------------------------------
-function logging.new(append, levels)
+function logging.new(append, params)
   if type(append) ~= "function" then
     return nil, "Appender must be a function."
   end
 
-  levels = levels or DEFAULT_LEVELS
+  local levels = (params or {}).levels or DEFAULT_LEVELS
   if type(levels) ~= "table" or #levels == 0 then
     return nil, "levels array must be a non-empty table"
   end

--- a/src/logging/console.lua
+++ b/src/logging/console.lua
@@ -10,14 +10,14 @@
 local logging = require"logging"
 
 function logging.console(params, ...)
-  params = logging.getDeprecatedParams({ "logPattern","levels" }, params, ...)
+  params = logging.getDeprecatedParams({ "logPattern", "levels" }, params, ...)
   local logPattern = params.logPattern
   local timestampPattern = params.timestampPattern
 
   return logging.new( function(self, level, message)
     io.stdout:write(logging.prepareLogMsg(logPattern, os.date(timestampPattern), level, message))
     return true
-  end,params.levels)
+  end, params.levels)
 end
 
 return logging.console

--- a/src/logging/console.lua
+++ b/src/logging/console.lua
@@ -10,14 +10,14 @@
 local logging = require"logging"
 
 function logging.console(params, ...)
-  params = logging.getDeprecatedParams({ "logPattern", "levels" }, params, ...)
+  params = logging.getDeprecatedParams({ "logPattern" }, params, ...)
   local logPattern = params.logPattern
   local timestampPattern = params.timestampPattern
 
   return logging.new( function(self, level, message)
     io.stdout:write(logging.prepareLogMsg(logPattern, os.date(timestampPattern), level, message))
     return true
-  end, params.levels)
+  end, params)
 end
 
 return logging.console

--- a/src/logging/console.lua
+++ b/src/logging/console.lua
@@ -10,14 +10,14 @@
 local logging = require"logging"
 
 function logging.console(params, ...)
-  params = logging.getDeprecatedParams({ "logPattern" }, params, ...)
+  params = logging.getDeprecatedParams({ "logPattern","levels" }, params, ...)
   local logPattern = params.logPattern
   local timestampPattern = params.timestampPattern
 
   return logging.new( function(self, level, message)
     io.stdout:write(logging.prepareLogMsg(logPattern, os.date(timestampPattern), level, message))
     return true
-  end)
+  end,params.levels)
 end
 
 return logging.console

--- a/src/logging/email.lua
+++ b/src/logging/email.lua
@@ -38,7 +38,7 @@ function logging.email(params)
     end
 
     return true
-  end,params.levels)
+  end, params.levels)
 end
 
 return logging.email

--- a/src/logging/email.lua
+++ b/src/logging/email.lua
@@ -38,7 +38,7 @@ function logging.email(params)
     end
 
     return true
-  end, params.levels)
+  end, params)
 end
 
 return logging.email

--- a/src/logging/email.lua
+++ b/src/logging/email.lua
@@ -38,7 +38,7 @@ function logging.email(params)
     end
 
     return true
-  end)
+  end,params.levels)
 end
 
 return logging.email

--- a/src/logging/file.lua
+++ b/src/logging/file.lua
@@ -30,7 +30,7 @@ local openFileLogger = function (filename, datePattern)
 end
 
 function logging.file(params, ...)
-  params = logging.getDeprecatedParams({ "filename", "datePattern", "logPattern", "levels" }, params, ...)
+  params = logging.getDeprecatedParams({ "filename", "datePattern", "logPattern" }, params, ...)
   local filename = params.filename
   local datePattern = params.datePattern
   local logPattern = params.logPattern
@@ -48,7 +48,7 @@ function logging.file(params, ...)
     local s = logging.prepareLogMsg(logPattern, os.date(timestampPattern), level, message)
     f:write(s)
     return true
-  end, params.levels)
+  end, params)
 end
 
 return logging.file

--- a/src/logging/file.lua
+++ b/src/logging/file.lua
@@ -30,7 +30,7 @@ local openFileLogger = function (filename, datePattern)
 end
 
 function logging.file(params, ...)
-  params = logging.getDeprecatedParams({ "filename", "datePattern", "logPattern","levels" }, params, ...)
+  params = logging.getDeprecatedParams({ "filename", "datePattern", "logPattern", "levels" }, params, ...)
   local filename = params.filename
   local datePattern = params.datePattern
   local logPattern = params.logPattern
@@ -48,7 +48,7 @@ function logging.file(params, ...)
     local s = logging.prepareLogMsg(logPattern, os.date(timestampPattern), level, message)
     f:write(s)
     return true
-  end,params.levels)
+  end, params.levels)
 end
 
 return logging.file

--- a/src/logging/file.lua
+++ b/src/logging/file.lua
@@ -30,7 +30,7 @@ local openFileLogger = function (filename, datePattern)
 end
 
 function logging.file(params, ...)
-  params = logging.getDeprecatedParams({ "filename", "datePattern", "logPattern" }, params, ...)
+  params = logging.getDeprecatedParams({ "filename", "datePattern", "logPattern","levels" }, params, ...)
   local filename = params.filename
   local datePattern = params.datePattern
   local logPattern = params.logPattern
@@ -48,7 +48,7 @@ function logging.file(params, ...)
     local s = logging.prepareLogMsg(logPattern, os.date(timestampPattern), level, message)
     f:write(s)
     return true
-  end)
+  end,params.levels)
 end
 
 return logging.file

--- a/src/logging/rolling_file.lua
+++ b/src/logging/rolling_file.lua
@@ -54,7 +54,7 @@ end
 
 
 function logging.rolling_file(params, ...)
-  params = logging.getDeprecatedParams({ "filename", "maxFileSize", "maxBackupIndex", "logPattern" }, params, ...)
+  params = logging.getDeprecatedParams({ "filename", "maxFileSize", "maxBackupIndex", "logPattern","levels" }, params, ...)
   local logPattern = params.logPattern
   local timestampPattern = params.timestampPattern
 
@@ -72,7 +72,7 @@ function logging.rolling_file(params, ...)
     local s = logging.prepareLogMsg(logPattern, os.date(timestampPattern), level, message)
     f:write(s)
     return true
-  end)
+  end,params.levels)
 end
 
 return logging.rolling_file

--- a/src/logging/rolling_file.lua
+++ b/src/logging/rolling_file.lua
@@ -54,7 +54,7 @@ end
 
 
 function logging.rolling_file(params, ...)
-  params = logging.getDeprecatedParams({ "filename", "maxFileSize", "maxBackupIndex", "logPattern", "levels" }, params, ...)
+  params = logging.getDeprecatedParams({ "filename", "maxFileSize", "maxBackupIndex", "logPattern" }, params, ...)
   local logPattern = params.logPattern
   local timestampPattern = params.timestampPattern
 
@@ -72,7 +72,7 @@ function logging.rolling_file(params, ...)
     local s = logging.prepareLogMsg(logPattern, os.date(timestampPattern), level, message)
     f:write(s)
     return true
-  end, params.levels)
+  end, params)
 end
 
 return logging.rolling_file

--- a/src/logging/rolling_file.lua
+++ b/src/logging/rolling_file.lua
@@ -54,7 +54,7 @@ end
 
 
 function logging.rolling_file(params, ...)
-  params = logging.getDeprecatedParams({ "filename", "maxFileSize", "maxBackupIndex", "logPattern","levels" }, params, ...)
+  params = logging.getDeprecatedParams({ "filename", "maxFileSize", "maxBackupIndex", "logPattern", "levels" }, params, ...)
   local logPattern = params.logPattern
   local timestampPattern = params.timestampPattern
 
@@ -72,7 +72,7 @@ function logging.rolling_file(params, ...)
     local s = logging.prepareLogMsg(logPattern, os.date(timestampPattern), level, message)
     f:write(s)
     return true
-  end,params.levels)
+  end, params.levels)
 end
 
 return logging.rolling_file

--- a/src/logging/socket.lua
+++ b/src/logging/socket.lua
@@ -32,7 +32,7 @@ function logging.socket(params, ...)
     socket:close()
 
     return true
-  end,params.levels)
+  end, params.levels)
 end
 
 return logging.socket

--- a/src/logging/socket.lua
+++ b/src/logging/socket.lua
@@ -11,7 +11,7 @@ local logging = require"logging"
 local socket = require"socket"
 
 function logging.socket(params, ...)
-  params = logging.getDeprecatedParams({ "hostname", "port", "logPattern", "levels" }, params, ...)
+  params = logging.getDeprecatedParams({ "hostname", "port", "logPattern" }, params, ...)
   local hostname = params.hostname
   local port = params.port
   local logPattern = params.logPattern
@@ -32,7 +32,7 @@ function logging.socket(params, ...)
     socket:close()
 
     return true
-  end, params.levels)
+  end, params)
 end
 
 return logging.socket

--- a/src/logging/socket.lua
+++ b/src/logging/socket.lua
@@ -11,7 +11,7 @@ local logging = require"logging"
 local socket = require"socket"
 
 function logging.socket(params, ...)
-  params = logging.getDeprecatedParams({ "hostname", "port", "logPattern" }, params, ...)
+  params = logging.getDeprecatedParams({ "hostname", "port", "logPattern", "levels" }, params, ...)
   local hostname = params.hostname
   local port = params.port
   local logPattern = params.logPattern
@@ -32,7 +32,7 @@ function logging.socket(params, ...)
     socket:close()
 
     return true
-  end)
+  end,params.levels)
 end
 
 return logging.socket

--- a/src/logging/sql.lua
+++ b/src/logging/sql.lua
@@ -55,7 +55,7 @@ function logging.sql(params)
     end
 
     return true
-  end)
+  end,params.levels)
 end
 
 return logging.sql

--- a/src/logging/sql.lua
+++ b/src/logging/sql.lua
@@ -55,7 +55,7 @@ function logging.sql(params)
     end
 
     return true
-  end,params.levels)
+  end, params.levels)
 end
 
 return logging.sql

--- a/src/logging/sql.lua
+++ b/src/logging/sql.lua
@@ -55,7 +55,7 @@ function logging.sql(params)
     end
 
     return true
-  end, params.levels)
+  end, params)
 end
 
 return logging.sql

--- a/tests/generic.lua
+++ b/tests/generic.lua
@@ -13,7 +13,7 @@ function logging.test(params)
     --print("----->",last_msg)
     call_count = call_count + 1
     return true
-  end)
+  end, params.levels)
 end
 
 local function reset()
@@ -80,6 +80,43 @@ tests.log_levels = function()
   logger:fatal("message 7")  -- should not change the last message
   assert(last_msg == "message 4", "got: " .. tostring(last_msg))
   assert(call_count == 3, "Got: " ..  tostring(call_count))
+end
+
+
+tests.custom_log_levels = function()
+  -- existing properties are not allowed as level names
+  local custom_levels = { "append", "debug" }
+  local logger, err = logging.test {
+    logPattern = "%message",
+    timestampPattern = nil,
+    levels = custom_levels,
+  }
+  assert(not logger)
+  assert(err:find("'APPEND' is not a proper level name"), "got: " .. tostring(err))
+
+
+  local custom_levels = { "hello", "world" }
+  local logger = logging.test {
+    logPattern = "%message",
+    timestampPattern = nil,
+    levels = custom_levels,
+  }
+  -- generates the levels
+  assert(logger.HELLO == "HELLO", "got: " .. tostring(logger.HELLO))
+  assert(logger.WORLD == "WORLD", "got: " .. tostring(logger.WORLD))
+  -- debug no longer exists
+  local success, err = pcall(function()
+    logger:setLevel(logger.DEBUG)
+  end)
+  assert(not success)
+  assert(err:find("undefined level `nil'"), "got: " .. tostring(err))
+  -- 'hello' exists
+  local success, err = pcall(function()
+    logger:setLevel(logger.HELLO)
+  end)
+  assert(success)
+  assert(err == nil, "got: " .. tostring(err))
+  logger:hello("my message")
 end
 
 

--- a/tests/generic.lua
+++ b/tests/generic.lua
@@ -13,7 +13,7 @@ function logging.test(params)
     --print("----->",last_msg)
     call_count = call_count + 1
     return true
-  end, params.levels)
+  end, params)
 end
 
 local function reset()

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -7,6 +7,7 @@ local test = {
   "testSocket.lua",
   "testSQL.lua",
   "testRollingFile.lua",
+  "testConsole_custom.lua",
 }
 
 print ("Start of Logging tests")

--- a/tests/testConsole_custom.lua
+++ b/tests/testConsole_custom.lua
@@ -10,5 +10,5 @@ logger:detail("string with %4")
 logger:setLevel("INFO2") -- test log level change warning.
 logger:info1("logging.console test")
 
-print("Console Logging OK")
+print("Console Logging with custom levels OK")
 

--- a/tests/testConsole_custom.lua
+++ b/tests/testConsole_custom.lua
@@ -1,0 +1,14 @@
+local log_console = require"logging.console"
+
+local logger = log_console({levels = {"DETAIL","INFO1","INFO2","WARN1","WARN2","ERROR","FATAL","OFF"}})
+
+logger:info1("logging.console test")
+logger:info2("logging.console info2 test")
+logger:detail("some details...")
+logger:error("error!")
+logger:detail("string with %4")
+logger:setLevel("INFO2") -- test log level change warning.
+logger:info1("logging.console test")
+
+print("Console Logging OK")
+


### PR DESCRIPTION
This will allow creating custom levels at startup. The default functionality remains the same. The added functionality is for optional use to allow customization of the logging levels.