### PR TITLE
Provide verbose error message when formatting fails

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -116,6 +116,7 @@ LuaLogging can be downloaded from its
 <dl class="history">
     <dt><strong>1.x.0</strong> [unreleased]</dt>
     <dd>Added: Functionality to specify custom log levels.</dd>
+    <dd>Added: Provide verbose error message when formatting fails.</dd>
 
     <dt><strong>1.4.0</strong> [12/Aug/2020]</dt>
     <dd>Fix: No more global on Lua 5.3.</dd>

--- a/src/logging.lua
+++ b/src/logging.lua
@@ -29,7 +29,17 @@ local function LOG_MSG(self, level, fmt, ...)
   local f_type = type(fmt)
   if f_type == 'string' then
     if select('#', ...) > 0 then
-      local status, msg = pcall(format, fmt, ...)
+      local function error_handler(err)
+        local r = ''
+        local m = debug.traceback(err, 5)
+        for s in m:gmatch("(.-)\n") do
+          if s:match("%:%d+%:") then
+            r = r .. ' | ' .. s:gsub('\t', '')
+          end
+        end
+        return err .. r
+      end
+      local status, msg = xpcall(format, error_handler, fmt, ...)
       if status then
         return self:append(level, msg)
       else

--- a/tests/generic.lua
+++ b/tests/generic.lua
@@ -147,15 +147,15 @@ tests.print_function = function()
 end
 
 
-tests.formatting = function()
+tests.format_error_stacktrace = function()
   local count = 0
   local logger = logging.test { logPattern = "%level %message" }
 
   logger:debug("%s-%s", 'abc', '007')
   assert(last_msg == 'DEBUG abc-007')
 
-  logger:debug("%s", nil)
-  assert(last_msg:find("bad argument #2 to 'format' %(no value%)"))
+  logger:debug("%s=%s", nil)
+  assert(last_msg:find("bad argument #%d to '(.-)' %(no value%)"))
   assert(last_msg:find("in main chunk"))
   assert(last_msg:find("in function 'func'"))
   local _, levels = last_msg:gsub("(|)", function() count = count + 1 end)

--- a/tests/generic.lua
+++ b/tests/generic.lua
@@ -150,8 +150,12 @@ end
 tests.formatting = function()
   local count = 0
   local logger = logging.test { logPattern = "%level %message" }
+
+  logger:debug("%s-%s", 'abc', '007')
+  assert(last_msg == 'DEBUG abc-007')
+
   logger:debug("%s", nil)
-  assert(last_msg:find("string expected, got no value"))
+  assert(last_msg:find("bad argument #2 to 'format' %(no value%)"))
   assert(last_msg:find("in main chunk"))
   assert(last_msg:find("in function 'func'"))
   local _, levels = last_msg:gsub("(|)", function() count = count + 1 end)

--- a/tests/generic.lua
+++ b/tests/generic.lua
@@ -147,6 +147,18 @@ tests.print_function = function()
 end
 
 
+tests.formatting = function()
+  local count = 0
+  local logger = logging.test { logPattern = "%level %message" }
+  logger:debug("%s", nil)
+  assert(last_msg:find("string expected, got no value"))
+  assert(last_msg:find("in main chunk"))
+  assert(last_msg:find("in function 'func'"))
+  local _, levels = last_msg:gsub("(|)", function() count = count + 1 end)
+  assert(levels == 3, "got : " .. levels)
+end
+
+
 for name, func in pairs(tests) do
   reset()
   print("generic test: " .. name)


### PR DESCRIPTION
Currently if the formatting of the log message fails it's quite hard to
find the source of the failure as one can find only following message in
the logs:

```lua
DEBUG Error formatting log message: bad argument #1 to '?' (string expected, got no value)
```

This patch adds stack trace to the error message which should make it
more clear where to find the source of the problem:

```lua
DEBUG Error formatting log message: bad argument #1 to '?' (string expected, got no value) | generic.lua:153: in function 'func' | generic.lua:166: in main chunk | test.lua:15: in main chunk
```