### PR TITLE
logging: file: disable buffering on the output log files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:
@@ -14,11 +14,11 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - uses: leafo/gh-actions-lua@v5
+    - uses: leafo/gh-actions-lua@v8.0.0
       with:
         luaVersion: ${{ matrix.luaVersion }}
 
-    - uses: leafo/gh-actions-luarocks@v2
+    - uses: leafo/gh-actions-luarocks@v4.0.0
 
     - name: setup
       run: |

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,6 +117,7 @@ LuaLogging can be downloaded from its
     <dt><strong>1.x.0</strong> [unreleased]</dt>
     <dd>Added: Functionality to specify custom log levels.</dd>
     <dd>Added: Provide verbose error message when formatting fails.</dd>
+    <dd>Fix: disable buffering on windows files</dd>
 
     <dt><strong>1.4.0</strong> [12/Aug/2020]</dt>
     <dd>Fix: No more global on Lua 5.3.</dd>

--- a/src/logging/file.lua
+++ b/src/logging/file.lua
@@ -12,12 +12,24 @@ local logging = require"logging"
 local lastFileNameDatePattern
 local lastFileHandler
 
+local buffer_mode do
+  local dir_separator = _G.package.config:sub(1,1)
+  local is_windows = dir_separator == '\\'
+  if is_windows then
+    -- Windows does not support "line" buffered mode, see
+    -- https://github.com/lunarmodules/lualogging/pull/9
+    buffer_mode = "no"
+  else
+    buffer_mode = "line"
+  end
+end
+
 local openFileLogger = function (filename, datePattern)
   local filename = string.format(filename, os.date(datePattern))
   if (lastFileNameDatePattern ~= filename) then
     local f = io.open(filename, "a")
     if (f) then
-      f:setvbuf ("line")
+      f:setvbuf(buffer_mode)
       lastFileNameDatePattern = filename
       lastFileHandler = f
       return f

--- a/src/logging/rolling_file.lua
+++ b/src/logging/rolling_file.lua
@@ -10,12 +10,24 @@
 
 local logging = require"logging"
 
+local buffer_mode do
+  local dir_separator = _G.package.config:sub(1,1)
+  local is_windows = dir_separator == '\\'
+  if is_windows then
+    -- Windows does not support "line" buffered mode, see
+    -- https://github.com/lunarmodules/lualogging/pull/9
+    buffer_mode = "no"
+  else
+    buffer_mode = "line"
+  end
+end
+
 local function openFile(self)
   self.file = io.open(self.filename, "a")
   if not self.file then
     return nil, string.format("file `%s' could not be opened for writing", self.filename)
   end
-  self.file:setvbuf ("line")
+  self.file:setvbuf(buffer_mode)
   return self.file
 end
 

--- a/tests/testFile.lua
+++ b/tests/testFile.lua
@@ -1,6 +1,18 @@
 local GLOBAL_OS_DATE = os.date
 local GLOBAL_IO_OPEN = io.open
 
+local buffer_mode do
+  local dir_separator = _G.package.config:sub(1,1)
+  local is_windows = dir_separator == '\\'
+  if is_windows then
+    -- Windows does not support "line" buffered mode, see
+    -- https://github.com/lunarmodules/lualogging/pull/9
+    buffer_mode = "no"
+  else
+    buffer_mode = "line"
+  end
+end
+
 local mock = {
   date = nil,
   handle = {}
@@ -39,7 +51,7 @@ logger:info("logging.file test")
 
 assert(mock.handle["__TEST"..mock.date..".log"].mode == "a")
 assert(#mock.handle["__TEST"..mock.date..".log"].lines == 1)
-assert(mock.handle["__TEST"..mock.date..".log"].setvbuf == "line")
+assert(mock.handle["__TEST"..mock.date..".log"].setvbuf == buffer_mode)
 assert(mock.handle["__TEST"..mock.date..".log"].lines[1] == "2008-01-01 INFO logging.file test\n")
 
 mock.date = "2008-01-02"
@@ -49,7 +61,7 @@ logger:error("error!")
 
 assert(mock.handle["__TEST"..mock.date..".log"].mode == "a")
 assert(#mock.handle["__TEST"..mock.date..".log"].lines == 2)
-assert(mock.handle["__TEST"..mock.date..".log"].setvbuf == "line")
+assert(mock.handle["__TEST"..mock.date..".log"].setvbuf == buffer_mode)
 assert(mock.handle["__TEST"..mock.date..".log"].lines[1] == "2008-01-02 DEBUG debugging...\n")
 assert(mock.handle["__TEST"..mock.date..".log"].lines[2] == "2008-01-02 ERROR error!\n")
 
@@ -59,7 +71,7 @@ logger:info({id = "1"})
 
 assert(mock.handle["__TEST"..mock.date..".log"].mode == "a")
 assert(#mock.handle["__TEST"..mock.date..".log"].lines == 1)
-assert(mock.handle["__TEST"..mock.date..".log"].setvbuf == "line")
+assert(mock.handle["__TEST"..mock.date..".log"].setvbuf == buffer_mode)
 assert(mock.handle["__TEST"..mock.date..".log"].lines[1] == '2008-01-03 INFO {id = "1"}\n')
 
 os.date = GLOBAL_OS_DATE  --luacheck: ignore


### PR DESCRIPTION
I've observed following on Windows Server 2012 R2 running under VMWare
where the disk I/O is handled by `VMWare Virtual disk SCSI Disk Device`
storage.

Current line buffering makes live observing of log files with `tail -f`
quite unusable as the current line is always missing from the log file
until there is next line logged.

Sometimes log content is missing completly, usually when the running
application is terminated and the buffered log content is not flushed
properly to the disk.

Disabling buffering fixes the issues.

Signed-off-by: Petr Štetiar <ynezz@true.cz>