### PR TITLE
rolling_file: fix unhandled file:seek failure

### DIFF
--- a/src/logging/rolling_file.lua
+++ b/src/logging/rolling_file.lua
@@ -56,6 +56,11 @@ local openRollingFileLogger = function (self)
   end
 
   local filesize = self.file:seek("end", 0)
+  if not filesize then
+    self.file:close()
+    self.file = nil
+    return openFile(self)
+  end
 
   if (filesize < self.maxSize) then
     return self.file


### PR DESCRIPTION
In some rare cases file:seek can fail, which then leads to following
error:

 rolling_file.lua:60:attempt to compare nil with number

Fix it by handling the possible file:seek() error with reopening the log
file.

Signed-off-by: Petr Štetiar <ynezz@true.cz>