### PR TITLE
more source placeholders and format-compilation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -117,19 +117,21 @@ downloads page or installed via LuaRocks.
 <dl class="history">
     <dt><strong>1.6.0</strong> [unreleased]</dt>
     <dd><strong>Added</strong>: the <code>logPattern</code> can now be specified for each log-level individually.
-    This allows use cases like only adding "%source" on debug level, or injecting ansi-color coding
+    This allows use cases like only adding <code>"%source"</code> on debug level, or injecting ansi-color coding
     in for example the error log-level.</dd>
     <dd><strong>Added</strong>: new bundled appender; "nginx". This logger has no configuration options, but will
     simply pass any log messages on to the nginx log. When using LuaLogging in OpenResty, configure this logger.</dd>
     <dd><strong>Added</strong>: application level defaults. New functions <code>logging.defaultLogPatterns()</code>
       , <code>logging.defaultTimestampPattern()</code>, <code>logging.defaultLevel()</code>, and <code>logging.defaultLogger()</code>
-      can be used to get/set the
-      global application level defaults. Use carefully, this is global state, so
-      only applications should set those, libraries should not.</dd>
+      can be used to get/set the global application level defaults.</br>
+      Use carefully, this is global state, so only applications should set those, libraries should not.</dd>
     <dd><strong>Added</strong>: the included appenders now have an extra parameter to set
       log-level upon creation; <code>logLevel</code>.</dd>
-      <dd><strong>Added</strong>: the <code>logPattern</code> can now have a new placeholder, "%source", which will be
-    replaced by the source filename, line number, and function name from where the log call was made.</dd>
+    <dd><strong>Added</strong>: the <code>logPattern</code> can now have new placeholders:</br>
+      <code>"%file"</code> (source file), </br>
+      <code>"%line"</code> (source line), </br>
+      <code>"%function"</code> (function name), and </br>
+      <code>"%source"</code> (evaluates to <code>"%file:%line in function '%function'"</code>).</dd>
     <dd><strong>Added</strong>: the console logger has a new optional parameter "destination",
       which must be either "stderr" or "stdout" (defaults to "stdout")</dd>
 

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -129,9 +129,9 @@ local patterns = logging.buildLogPatterns(
   </br>
     The default is <code>"%date %level %message\n"</code> for all log-levels.</br>
   </br>
-    Available placeholders in the pattern string are; "%date", "%level", "%message",
-    and "%source". The "%source" placeholder will return filename, line number, and
-    function name.</br>
+    Available placeholders in the pattern string are; <code>"%date"</code>, <code>"%level"</code>, <code>"%message"</code>,
+    <code>"%file"</code>, <code>"%line"</code>, <code>"%function"</code> and <code>"%source"</code>. The <code>"%source"</code> placeholder evaluates
+    to <code>"%file:%line in function'%function'"</code>.</br>
   </br>
     Returns the current defaultLogPatterns value.</br>
   </br>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -174,7 +174,24 @@ local patterns = logging.buildLogPatterns(
     only applications should. Libraries should get this logger and use it, assuming
     the application has set it.
     <pre class="example">
--- library example
+-- Example: application setting the default logger
+local color = require("ansicolors") -- https://github.com/kikito/ansicolors.lua
+local ll = require("logging")
+require "logging.console"
+ll.defaultLogger(ll.console {
+  destination = "stderr",
+  timestampPattern = "!%y-%m-%dT%H:%M:%SZ", -- ISO 8601 in UTC
+  logPatterns = {
+    [ll.DEBUG] = color("%{white}%date%{cyan} %level %message (%source)\n"),
+    [ll.INFO] = color("%{white}%date%{white} %level %message\n"),
+    [ll.WARN] = color("%{white}%date%{yellow} %level %message\n"),
+    [ll.ERROR] = color("%{white}%date%{red bright} %level %message %{cyan}(%source)\n"),
+    [ll.FATAL] = color("%{white}%date%{magenta bright} %level %message %{cyan}(%source)\n"),
+  }
+})
+
+
+-- Example: library using default if available (fallback to nop)
 local log do
   local ll = package.loaded.logging
   if ll and type(ll) == "table" and ll.defaultLogger and

--- a/src/logging.lua
+++ b/src/logging.lua
@@ -290,7 +290,7 @@ function logging.defaultLogPatterns(patt)
     if type(patt) == "string" then
       patt = logging.buildLogPatterns({}, patt)
     end
-    assert(type(patt) ~= "table", "logPatterns must be a string or a table, got: %s", tostring(patt))
+    assert(type(patt) == "table", "logPatterns must be a string or a table, got: %s", type(patt))
     for _, level in ipairs(LEVELS) do
       if level ~= "OFF" then
         assert(type(patt[level]) == "string", "the patterns contains a '%s' value (instead of a string) for level '%s'", type(patt[level]), level)


### PR DESCRIPTION
adds format placeholders "file", "line", "function". And now compiles the format string into a function, reducing a number of 'gsub' calls to a single string concat.