### PR TITLE
feat(timestamp) add new %q placholder for millisec timestamp 

### DIFF
--- a/docs/console.html
+++ b/docs/console.html
@@ -99,7 +99,9 @@ function logging.console {
 
     <li><code>timestampPattern</code>:<br />
     This is an optional parameter that can be used to specify a date/time formatting
-    in the log message. The default is taken from <code>logging.defaultTimestampPattern()</code>.</li>
+    in the log message.
+    See <code>logging.date</code> for the format.
+    The default is taken from <code>logging.defaultTimestampPattern()</code>.</li>
 
     <li><code>destination</code>:<br />
     The destination stream, optional. The value can be either <code>"stdout"</code>,

--- a/docs/file.html
+++ b/docs/file.html
@@ -117,7 +117,9 @@ function logging.file {
 
     <li><code>timestampPattern</code>:<br />
       This is an optional parameter that can be used to specify a date/time formatting
-      in the log message. The default is taken from <code>logging.defaultTimestampPattern()</code>.</li>
+      in the log message.
+      See <code>logging.date</code> for the format.
+      The default is taken from <code>logging.defaultTimestampPattern()</code>.</li>
 
     <li><code>logLevel</code>:<br />
       The initial log-level to set for the created logger.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -123,14 +123,14 @@ downloads page or installed via LuaRocks.
     simply pass any log messages on to the nginx log. When using LuaLogging in OpenResty, configure this logger.</dd>
     <dd><strong>Added</strong>: application level defaults. New functions <code>logging.defaultLogPatterns()</code>
       , <code>logging.defaultTimestampPattern()</code>, <code>logging.defaultLevel()</code>, and <code>logging.defaultLogger()</code>
-      can be used to get/set the global application level defaults.</br>
+      can be used to get/set the global application level defaults.<br/>
       Use carefully, this is global state, so only applications should set those, libraries should not.</dd>
     <dd><strong>Added</strong>: the included appenders now have an extra parameter to set
       log-level upon creation; <code>logLevel</code>.</dd>
-    <dd><strong>Added</strong>: the <code>logPattern</code> can now have new placeholders:</br>
-      <code>"%file"</code> (source file), </br>
-      <code>"%line"</code> (source line), </br>
-      <code>"%function"</code> (function name), and </br>
+    <dd><strong>Added</strong>: the <code>logPattern</code> can now have new placeholders:<br/>
+      <code>"%file"</code> (source file), <br/>
+      <code>"%line"</code> (source line), <br/>
+      <code>"%function"</code> (function name), and <br/>
       <code>"%source"</code> (evaluates to <code>"%file:%line in function '%function'"</code>).</dd>
     <dd><strong>Added</strong>: the console logger has a new optional parameter "destination",
       which must be either "stderr" or "stdout" (defaults to "stdout")</dd>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -104,10 +104,10 @@ or alternatively using the <code>Makefile</code>.</p>
   <dt><strong>patts = logging.buildLogPatterns([table], [string])</strong></dt>
   <dd>Creates a log-patterns table. The returned table will for each level have
     the logPattern set to 1. the value in the table, or alternatively 2. the
-    string value, or 3. the pattern from the global defaults.</br>
-  </br>
-    Returns a logPatterns table.</br>
-  </br>
+    string value, or 3. the pattern from the global defaults.<br/>
+  <br/>
+    Returns a logPatterns table.<br/>
+  <br/>
     Example logging source info only on debug-level, and coloring error and fatal
     messages:
     <pre class="example">
@@ -125,16 +125,16 @@ local patterns = logging.buildLogPatterns(
   <dd>Sets the default logPatterns (global!) if a parameter is given.
     If the parameter is a string then that string will be used as the pattern for
     all log-levels. If a table is given, then it must have all log-levels defined
-    with a pattern string. See also <code>logging.buildLogPatterns</code>.</br>
-  </br>
-    The default is <code>"%date %level %message\n"</code> for all log-levels.</br>
-  </br>
+    with a pattern string. See also <code>logging.buildLogPatterns</code>.<br/>
+  <br/>
+    The default is <code>"%date %level %message\n"</code> for all log-levels.<br/>
+  <br/>
     Available placeholders in the pattern string are; <code>"%date"</code>, <code>"%level"</code>, <code>"%message"</code>,
     <code>"%file"</code>, <code>"%line"</code>, <code>"%function"</code> and <code>"%source"</code>. The <code>"%source"</code> placeholder evaluates
-    to <code>"%file:%line in function'%function'"</code>.</br>
-  </br>
-    Returns the current defaultLogPatterns value.</br>
-  </br>
+    to <code>"%file:%line in function'%function'"</code>.<br/>
+  <br/>
+    Returns the current defaultLogPatterns value.<br/>
+  <br/>
     <em>NOTE:</em> since this is a global setting, libraries should never set it,
     only applications should.
   </dd>
@@ -143,10 +143,10 @@ local patterns = logging.buildLogPatterns(
   <dd>Sets the default timestampPattern (global!) if given.
     The default is <code>nil</code>, which results in a system specific date/time format.
     The pattern should be accepted by the Lua function
-    <a href="https://www.lua.org/manual/5.1/manual.html#pdf-os.date"><code>os.date</code></a> for formatting.</br>
-  </br>
-    Returns the current defaultTimestampPattern value.</br>
-  </br>
+    <a href="https://www.lua.org/manual/5.1/manual.html#pdf-os.date"><code>os.date</code></a> for formatting.<br/>
+  <br/>
+    Returns the current defaultTimestampPattern value.<br/>
+  <br/>
     <em>NOTE:</em> since this is a global setting, libraries should never set it,
     only applications should.
   </dd>
@@ -154,10 +154,10 @@ local patterns = logging.buildLogPatterns(
   <dt><strong>level = logging.defaultLevel([level constant])</strong></dt>
   <dd>Sets the default log-level (global!) if given. Each new logger object created
     will start with the log-level as specified by this value.
-    The level parameter must be one of the log-level constants. The default is <code>logging.DEBUG</code>.</br>
-  </br>
-    Returns the current defaultLevel value.</br>
-  </br>
+    The level parameter must be one of the log-level constants. The default is <code>logging.DEBUG</code>.<br/>
+  <br/>
+    Returns the current defaultLevel value.<br/>
+  <br/>
     <em>NOTE:</em> since this is a global setting, libraries should never set it,
     only applications should.
   </dd>
@@ -166,10 +166,10 @@ local patterns = logging.buildLogPatterns(
   <dd>Sets the default logger object (global!) if given.
     The logger parameter must be a LuaLogging logger object. The default is to
     generate a new <code>console</code> logger (with "destination" set to "stderr")
-    on the first call to get the default logger.</br>
-  </br>
-    Returns the current defaultLogger value.</br>
-  </br>
+    on the first call to get the default logger.<br/>
+  <br/>
+    Returns the current defaultLogger value.<br/>
+  <br/>
     <em>NOTE:</em> since this is a global setting, libraries should never set it,
     only applications should. Libraries should get this logger and use it, assuming
     the application has set it.

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -121,6 +121,21 @@ local patterns = logging.buildLogPatterns(
       </pre>
   </dd>
 
+  <dt><strong>date_val = logging.date([format,[time]])</strong></dt>
+  <dd>Compatible with standard Lua <code>os.date()</code> function, but supports second fractions.
+    The placeholder in the format string is <code>"%q"</code>, or <code>"%1q"</code> to <code>"%6q"</code>,
+    where the number 1-6 specifies the number of decimals. The default is 3, so <code>"%q"</code> is the same
+    as <code>"%3q"</code>. The format will always have the specified length, padded with leading and trailing 0's
+    where necessary.<br/>
+    If the pattern is <code>"*t"</code>, then the returned table will have an extra field <code>"secf"</code> that holds
+    the fractional part.<br/>
+    <br/>
+    Example: <code>"%y-%m-%d %H:%M:%S.%6q"</code><br/>
+    <br/>
+    Note: if the "time" parameter is not provided, it will try and use the LuaSocket function <code>gettime()</code>
+    to get the time. If unavailable, the fractional part will be set to 0.
+  </dd>
+
   <dt><strong>patts = logging.defaultLogPatterns([string | table])</strong></dt>
   <dd>Sets the default logPatterns (global!) if a parameter is given.
     If the parameter is a string then that string will be used as the pattern for
@@ -180,7 +195,7 @@ local ll = require("logging")
 require "logging.console"
 ll.defaultLogger(ll.console {
   destination = "stderr",
-  timestampPattern = "!%y-%m-%dT%H:%M:%SZ", -- ISO 8601 in UTC
+  timestampPattern = "!%y-%m-%dT%H:%M:%S.%qZ", -- ISO 8601 in UTC
   logPatterns = {
     [ll.DEBUG] = color("%{white}%date%{cyan} %level %message (%source)\n"),
     [ll.INFO] = color("%{white}%date%{white} %level %message\n"),

--- a/docs/rolling_file.html
+++ b/docs/rolling_file.html
@@ -121,7 +121,9 @@ function logging.rolling_file {
 
     <li><code>timestampPattern</code>:<br />
       This is an optional parameter that can be used to specify a date/time formatting
-      in the log message. The default is taken from <code>logging.defaultTimestampPattern()</code>.</li>
+      in the log message.
+      See <code>logging.date</code> for the format.
+      The default is taken from <code>logging.defaultTimestampPattern()</code>.</li>
 
     <li><code>logLevel</code>:<br />
       The initial log-level to set for the created logger.</li>

--- a/docs/socket.html
+++ b/docs/socket.html
@@ -111,7 +111,9 @@ function logging.socket {
 
     <li><code>timestampPattern</code>:<br />
       This is an optional parameter that can be used to specify a date/time formatting
-      in the log message. The default is taken from <code>logging.defaultTimestampPattern()</code>.</li>
+      in the log message.
+      See <code>logging.date</code> for the format.
+      The default is taken from <code>logging.defaultTimestampPattern()</code>.</li>
 
     <li><code>logLevel</code>:<br />
       The initial log-level to set for the created logger.</li>

--- a/src/logging/console.lua
+++ b/src/logging/console.lua
@@ -32,7 +32,7 @@ function logging.console(params, ...)
   local logPatterns = logging.buildLogPatterns(params.logPatterns, params.logPattern)
 
   return logging.new( function(self, level, message)
-    io[destination]:write(prepareLogMsg(logPatterns[level], os.date(timestampPattern), level, message))
+    io[destination]:write(prepareLogMsg(logPatterns[level], logging.date(timestampPattern), level, message))
     return true
   end, startLevel)
 end

--- a/src/logging/email.lua
+++ b/src/logging/email.lua
@@ -26,7 +26,7 @@ function logging.email(params)
   local startLevel = params.logLevel or logging.defaultLevel()
 
   return logging.new( function(self, level, message)
-    local dt = os.date(timestampPattern)
+    local dt = logging.date(timestampPattern)
     local s = logging.prepareLogMsg(logPatterns[level], dt, level, message)
     if params.headers.subject then
       params.headers.subject =

--- a/src/logging/file.lua
+++ b/src/logging/file.lua
@@ -25,7 +25,7 @@ local buffer_mode do
 end
 
 local openFileLogger = function (filename, datePattern)
-  local filename = string.format(filename, os.date(datePattern))
+  local filename = string.format(filename, logging.date(datePattern))
   if (lastFileNameDatePattern ~= filename) then
     local f = io.open(filename, "a")
     if (f) then
@@ -58,7 +58,7 @@ function logging.file(params, ...)
     if not f then
       return nil, msg
     end
-    local s = logging.prepareLogMsg(logPatterns[level], os.date(timestampPattern), level, message)
+    local s = logging.prepareLogMsg(logPatterns[level], logging.date(timestampPattern), level, message)
     f:write(s)
     return true
   end, startLevel)

--- a/src/logging/rolling_file.lua
+++ b/src/logging/rolling_file.lua
@@ -87,7 +87,7 @@ function logging.rolling_file(params, ...)
     if not f then
       return nil, msg
     end
-    local s = logging.prepareLogMsg(logPatterns[level], os.date(timestampPattern), level, message)
+    local s = logging.prepareLogMsg(logPatterns[level], logging.date(timestampPattern), level, message)
     f:write(s)
     return true
   end, startLevel)

--- a/src/logging/socket.lua
+++ b/src/logging/socket.lua
@@ -19,7 +19,7 @@ function logging.socket(params, ...)
   local startLevel = params.logLevel or logging.defaultLevel()
 
   return logging.new( function(self, level, message)
-    local s = logging.prepareLogMsg(logPatterns[level], os.date(timestampPattern), level, message)
+    local s = logging.prepareLogMsg(logPatterns[level], logging.date(timestampPattern), level, message)
 
     local socket, err = socket.connect(hostname, port)
     if not socket then


### PR DESCRIPTION
either `%q` or `%xq` where `x` is the number of decimals. If no `x` given
then defaults to 3 decimals. The value will always have the same
length, with trailing and leading zero's where necessary.