### PR TITLE
fix(rsyslog) remove failed and closed socket from the cache

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -113,6 +113,8 @@ downloads page or installed via LuaRocks.
     <dd><strong>Fix</strong>: add rsyslog appender to makefile install target.</dd>
     <dd><strong>Fix</strong>: errorhandler in rsyslog was omitting 'self', and also log the failed message itself to stderr.</dd>
     <dd><strong>Fix</strong>: when using Copas and rsyslog on Lua 5.1, coxpcall is required to yield.</dd>
+    <dd><strong>Fix</strong>: rsyslog; upon failure remove the closed socket from the cache to prevent the retry from using
+    the closed socket.</dd>
 
     <dt><strong>1.7.0</strong> [21/Sep/2022]</dt>
     <dd><strong>Added</strong>: new function <code>logging.date</code> is compatible with <code>os.date</code>

--- a/src/logging/rsyslog.lua
+++ b/src/logging/rsyslog.lua
@@ -187,6 +187,7 @@ function M.senders.udp(self, msg, is_retry)
   if not ok then
     sock:close()
     self.sock = nil
+    socket_cache[self.socket_cache_key] = nil
     -- recurse once; will recreate the socket and retry
     if not is_retry then
       return M.senders.udp(self, msg, true)
@@ -238,6 +239,7 @@ function M.senders.tcp(self, msg, is_retry)
     if not last_byte_send then
       sock:close()
       self.sock = nil
+      socket_cache[self.socket_cache_key] = nil
       -- recurse once; will recreate the socket and retry
       if not is_retry then
         return M.senders.tcp(self, msg, true)


### PR DESCRIPTION
Previously the retry would fetch the same socket from the cache if the GC hadn't run yet. By cleaning it will force creation of a new socket.