### PR TITLE
use explicit tostring, don't rely on automatic coercion

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -106,6 +106,9 @@ downloads page or installed via LuaRocks.
 <h2><a name="history"></a>History</h2>
 
 <dl class="history">
+    <dt><strong>1.x.0</strong> [unreleased]</dt>
+    <dd><strong>Fix</strong>: use explicit tostring, don't rely on automatic coercion.</dd>
+
     <dt><strong>1.8.0</strong> [22/Oct/2022]</dt>
     <dd><strong>Added</strong>: new module <code>logging.envconfig</code> to allow log configuration via
     environment variables.</dd>

--- a/src/logging.lua
+++ b/src/logging.lua
@@ -193,7 +193,7 @@ function logging.compilePattern(pattern)
     ["message"] = false,
     -- truthy: requires debug info to be fetched first
     ["file"] = "info.short_src",
-    ["line"] = "info.currentline",
+    ["line"] = "tostring(info.currentline)",
     ["function"] = '(info.name or "unknown function")',
   }
   local inject_info = false

--- a/src/logging/email.lua
+++ b/src/logging/email.lua
@@ -43,6 +43,7 @@ function M.new(params)
     end
     local msg = { headers = params.headers, body = s }
     params.source = smtp.message(msg)
+    params.port = "25"
 
     local r, e = smtp.send(params)
     if not r then

--- a/src/logging/rolling_file.lua
+++ b/src/logging/rolling_file.lua
@@ -37,7 +37,7 @@ end
 local rollOver = function (self)
   for i = self.maxIndex - 1, 1, -1 do
     -- files may not exist yet, lets ignore the possible errors.
-    os.rename(self.filename.."."..i, self.filename.."."..i+1)
+    os.rename(self.filename.."."..tostring(i), self.filename.."."..tostring(i+1))
   end
 
   self.file:close()

--- a/tests/generic.lua
+++ b/tests/generic.lua
@@ -197,7 +197,7 @@ tests.format_error_stacktrace = function()
   assert(last_msg:find("in main chunk"))
   assert(last_msg:find("in %w+ 'func'"))
   local _, levels = last_msg:gsub("(|)", function() count = count + 1 end)
-  assert(levels == 3, "got : " .. levels)
+  assert(levels == 3, "got : " .. tostring(levels))
 end
 
 

--- a/tests/testRollingFile.lua
+++ b/tests/testRollingFile.lua
@@ -17,7 +17,7 @@ end
 
 -- lets test if all files where created
 for i = 1, max_index do
-  local file = assert(io.open(log_filename.."."..i, "r"))
+  local file = assert(io.open(log_filename.."."..tostring(i), "r"))
   -- since there is an exact precision on the rolling
   -- (it can be a little less or a little more than the max_size)
   -- lets just test if the file is empty.

--- a/tests/testSocket.lua
+++ b/tests/testSocket.lua
@@ -1,6 +1,6 @@
 local log_sock = require"logging.socket"
 
-local logger = log_sock("localhost", 5000)
+local logger = log_sock("localhost", "5000")
 
 logger:info("logging.socket test")
 logger:debug("debugging...")


### PR DESCRIPTION
currently fails when using a Lua 5.3/5.4 interpreter built with LUA_NOCVTN2S defined