### PR TITLE
allow to work without debug library

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         luaVersion: [ "5.4", "5.3", "5.2", "5.1", "luajit" ] # , "luajit-openresty" ]
+        debug: ["", "_G.debug = nil"] # also run with debug lib disabled
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -29,3 +30,5 @@ jobs:
 
       - name: Run regression tests
         run: make test
+        env:
+          LUA_INIT: ${{ matrix.debug }}

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ install:
 
 test:
 	cd tests && ./run_tests.sh
+	cd tests && LUA_INIT="_G.debug = nil" ./run_tests.sh
 
 lint:
 	luacheck .

--- a/docs/index.html
+++ b/docs/index.html
@@ -106,6 +106,9 @@ downloads page or installed via LuaRocks.
 <h2><a name="history"></a>History</h2>
 
 <dl class="history">
+    <dt><strong>1.x.y</strong> [unreleased]</dt>
+    <dd><strong>Fix</strong>: allow to work without the debug library.</dd>
+
     <dt><strong>1.8.1</strong> [23/Jan/2023]</dt>
     <dd><strong>Fix</strong>: use explicit tostring, don't rely on automatic coercion.</dd>
     <dd><strong>Fix</strong>: rsyslog appender wouldn't properly clear the socket upon an error.</dd>

--- a/src/logging.lua
+++ b/src/logging.lua
@@ -39,7 +39,7 @@ local defaultLogger = nil
 local function rewrite_stacktrace()
   -- prettify stack-trace, remove lualogging entries and reformat to 1 line
   local result = ''
-  local trace = debug.traceback()
+  local trace = debug and debug.traceback() or ''
   for entry in trace:gmatch("%s*(.-)\n") do
     if entry:match("%:%d+%:") and not entry:find('logging.lua') then
       result = result .. ' | ' .. entry
@@ -179,7 +179,7 @@ end
 -- Prepares the log message
 -------------------------------------------------------------------------------
 local sourceDebugLevel = 1 -- this will be set dynamically below
-local getDebugInfoLine = "local info = debug.getinfo(%d)"
+local getDebugInfoLine = debug and "local info = debug.getinfo(%d)" or "local info = { short_src = '?', currentline = -1 }"
 
 function logging.compilePattern(pattern)
   pattern = string.format("%q", pattern)
@@ -431,7 +431,7 @@ end
 -------------------------------------------------------------------------------
 -- dynamically detect proper source debug level, since this can vary by Lua versions
 -------------------------------------------------------------------------------
-do
+if debug then
   local detection_logger, test_msg
 
   local function detect_func() detection_logger:debug("message") end -- This function MUST be on a single line!!

--- a/tests/generic.lua
+++ b/tests/generic.lua
@@ -139,10 +139,16 @@ tests.logPatterns = function()
   end
   test_func()
   assert(last_msg ~= "%source", "expected '%source' placeholder to be replaced, got: " .. tostring(last_msg))
-  assert(last_msg:find("'test_func'", 1, true), "expected function name in output, got: " .. tostring(last_msg))
-  assert(last_msg:find(":138 ", 1, true), "expected line number in output, got: " .. tostring(last_msg)) -- update hardcoded linenumber when this fails!
-  assert(last_msg:find("generic.lua:", 1, true), "expected filename in output, got: " .. tostring(last_msg))
-
+  if debug then
+    assert(last_msg:find("'test_func'", 1, true), "expected function name in output, got: " .. tostring(last_msg))
+    assert(last_msg:find(":138 ", 1, true), "expected line number in output, got: " .. tostring(last_msg)) -- update hardcoded linenumber when this fails!
+    assert(last_msg:find("generic.lua:", 1, true), "expected filename in output, got: " .. tostring(last_msg))
+  else
+    -- debug library disabled
+    assert(last_msg:find("'unknown function'", 1, true), "expected 'unknwon function' in output, got: " .. tostring(last_msg))
+    assert(last_msg:find(":-1 ", 1, true), "expected line number (-1) in output, got: " .. tostring(last_msg)) -- update hardcoded linenumber when this fails!
+    assert(last_msg:find("?:", 1, true), "expected filename ('?') in output, got: " .. tostring(last_msg))
+  end
   -- mutiple separate patterns
   local logger = logging.test {
     logPattern = "%message",
@@ -193,11 +199,13 @@ tests.format_error_stacktrace = function()
   assert(last_msg == 'DEBUG abc-007')
 
   logger:debug("%s=%s", nil)
-  assert(last_msg:find("bad argument #%d to '(.-)'"))
-  assert(last_msg:find("in main chunk"))
-  assert(last_msg:find("in %w+ 'func'"))
-  local _, levels = last_msg:gsub("(|)", function() count = count + 1 end)
-  assert(levels == 3, "got : " .. tostring(levels))
+  assert(last_msg:find("bad argument #%d to '(.-)'"), "msg:'"..last_msg.."'")
+  if debug then
+    assert(last_msg:find("in main chunk"), "msg:'"..last_msg.."'")
+    assert(last_msg:find("in %w+ 'func'"), "msg:'"..last_msg.."'")
+    local _, levels = last_msg:gsub("(|)", function() count = count + 1 end)
+    assert(levels == 3, "got : " .. tostring(levels))
+  end
 end
 
 


### PR DESCRIPTION
the use of [debug](https://www.lua.org/manual/5.4/manual.html#6.10) library could be not safe, or at least no recommended.

I want run code with a Lua interpreter compiled without this library `debug`.